### PR TITLE
TF1 to TF2 migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 # Application secrets
 rsyncd.conf
 secrets.yml
+hosts

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:1.12.0-gpu-py3
+FROM tensorflow/tensorflow:2.0.0rc0-gpu-py3-jupyter
 
 RUN pip3 install \
   bs4==0.0.1    `# known good with 0.0.1`  \

--- a/roles/jupyter/vars/main.yml
+++ b/roles/jupyter/vars/main.yml
@@ -3,6 +3,6 @@ jupyter:
   container_name: jupyter
   image:
     name: arricor/tensorflow # FROM tensorflow/tensorflow but adds our python libraries
-    tag: 1.12.0-gpu-py3
+    tag: 2.0.0rc0-gpu-py3-jupyter
   published_ports: 8888:8888
   volumes: "{{ volumes }}"

--- a/secrets.example.yml
+++ b/secrets.example.yml
@@ -3,7 +3,6 @@
 ################################################################################
 ---
 secrets:
-  jupyter_password: SuperSecretPassword
   sync:
     source: /nfs/data
     destination: /nfs
@@ -11,4 +10,4 @@ secrets:
     - ansible
   volumes:
     data: /nfs/data:/data
-    source: /nfs/src:/notebooks
+    source: /nfs/src:/tf


### PR DESCRIPTION
- added hosts to .gitignore
- change image tag in Dokerfile
- change image tag in jupyter role
- remove jupyter_password (its auto-generated now)
- rename /notebooks to /tf